### PR TITLE
Package ar-sync renaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
-PACKAGES=ar-release ar-consumer ar-sync ar-compute ar-local-compute ar-web-api poem ar-data-retention
-SRC_DIRS=../ar-release ../ar-consumer ../ar-sync ../ar-compute-engine ../ar-web-api ../poem ../ar-data-retention
-SPEC_FILES=../ar-release/ar-release.spec ../ar-consumer/ar-consumer.spec ../ar-sync/ar-sync.spec ../ar-compute-engine/ar-compute.spec ../ar-compute-engine/ar-local-compute.spec ../ar-web-api/ar-web-api.spec ../poem/poem.spec ../ar-data-retention/ar-data-retention.spec
+PACKAGES=ar-release ar-consumer argo-egi-connectors ar-compute ar-web-api poem ar-data-retention
+SRC_DIRS=../ar-release ../ar-consumer ../argo-egi-connectors ../ar-compute-engine ../ar-web-api ../poem ../ar-data-retention
+SPEC_FILES=../ar-release/ar-release.spec ../ar-consumer/ar-consumer.spec ../argo-egi-connectors/argo-egi-connectors.spec ../ar-compute-engine/ar-compute.spec ../ar-web-api/ar-web-api.spec ../poem/poem.spec ../ar-data-retention/ar-data-retention.spec
 
 sources:
 	for i in ${SRC_DIRS}; do cd $$i ; make sources ; done
-	cd ../ar-compute-engine; make -f Makefile.local sources ; cd ../ar-builder
 	for i in ${SRC_DIRS}; do mv $$i/*.tar.gz . ; done
 
 rpms: sources


### PR DESCRIPTION
Please merge this only as long as ARGOeu/argo-egi-connectors#36 is also merged. It mainly reflects the change in the name of the package ar-sync to argo-egi-connectors and a few more clean ups that have long been overdue.